### PR TITLE
change api url and remove bluemix button option

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ This is an npm module that can track and report details of a demo/tutorial that 
 
 1. Open a terminal and run  
    ```
-   npm install metrics-collector-client --save
+   npm install metrics-tracker-client --save
    ```
 2. Require the package in your main entry point to your app (probably app.js).  
     ```
-    require("metrics-collector-client").track();
+    require("metrics-tracker-client").track();
     ```
 3. Add a copy of the Privacy Notice to the readme file. 
 

--- a/README.md
+++ b/README.md
@@ -33,12 +33,11 @@ event_organizer: dev-journeys
 ```
 
 Required field:
-1. deploy_to_bluemix : Put **True** if your journey has a deploy to bluemix button. Else put **False**.
-2. id: Put your journey name/Github URL of your journey.
-3. runtimes: Put down all your platform runtime environments in a list.
-4. services: Put down all the bluemix services that are used in your journey in a list.
-5. event_id: Put down where you will distribute your journey. Default is **web**. 
-6. event_organizer: Put down your event organizer if you have one.
+1. id: Put your journey name/Github URL of your journey.
+2. runtimes: Put down all your platform runtime environments in a list.
+3. services: Put down all the bluemix services that are used in your journey in a list.
+4. event_id: Put down where you will distribute your journey. Default is **web**. 
+5. event_organizer: Put down your event organizer if you have one.
 
 # List of runtimes and services
 

--- a/metric_tracker.js
+++ b/metric_tracker.js
@@ -21,7 +21,6 @@ function combineData(data,cfData){
 	if(data.runtimes) cfData.config.target_runtimes = data.runtimes; else cfData.config.target_runtimes = "";
 	if(data.services) cfData.config.target_services = data.services; else cfData.config.target_services = "";
 	if(data.event_id) cfData.config.event_id = data.event_id; else cfData.config.event_id = "";
-	if(data.deploy_to_bluemix) cfData.config.deploy_to_bluemix = data.deploy_to_bluemix; else cfData.config.deploy_to_bluemix = "";
 	if(data.event_organizer) cfData.config.event_organizer = data.event_organizer; else cfData.config.event_organizer = "";
 	return cfData;
 	}catch(ex){

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metrics-collector-client",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "private": false,
   "main": "tracker.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "metrics-collector-client",
-  "version": "0.1.7",
+  "name": "metrics-tracker-client",
+  "version": "0.1.9",
   "private": false,
   "main": "tracker.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metrics-collector-client",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "private": false,
   "main": "tracker.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metrics-collector-client",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "private": false,
   "main": "tracker.js",
   "repository": {

--- a/tracker.js
+++ b/tracker.js
@@ -83,7 +83,7 @@ function track() {
         // restler.postJson('https://deployment-tracker.mybluemix.net/api/v1/track', event).on('complete', function (data) {
         // });
     }
-    var url = 'https://metricstracker.mybluemix.net/api/v1/track';
+    var url = 'https://metrics-collector.mybluemix.net/api/v1/track';
     if(journey_metric!=null){
         event = metric.massage(journey_metric,event);
     }

--- a/tracker.js
+++ b/tracker.js
@@ -83,7 +83,7 @@ function track() {
         // restler.postJson('https://deployment-tracker.mybluemix.net/api/v1/track', event).on('complete', function (data) {
         // });
     }
-    var url = 'https://metrics-collectors.mybluemix.net/api/v1/track';
+    var url = 'https://metrics-tracker.mybluemix.net/api/v1/track';
     if(journey_metric!=null){
         event = metric.massage(journey_metric,event);
     }

--- a/tracker.js
+++ b/tracker.js
@@ -83,7 +83,7 @@ function track() {
         // restler.postJson('https://deployment-tracker.mybluemix.net/api/v1/track', event).on('complete', function (data) {
         // });
     }
-    var url = 'https://metrics-collector.mybluemix.net/api/v1/track';
+    var url = 'https://metrics-collectors.mybluemix.net/api/v1/track';
     if(journey_metric!=null){
         event = metric.massage(journey_metric,event);
     }

--- a/tracker.js
+++ b/tracker.js
@@ -83,7 +83,7 @@ function track() {
         // restler.postJson('https://deployment-tracker.mybluemix.net/api/v1/track', event).on('complete', function (data) {
         // });
     }
-    var url = 'https://trackermetric.mybluemix.net/api/v1/track';
+    var url = 'https://metricstracker.mybluemix.net/api/v1/track';
     if(journey_metric!=null){
         event = metric.massage(journey_metric,event);
     }


### PR DESCRIPTION
- change API endpoint to https://metrics-tracker.mybluemix.net/ 
- No long parse bluemix button option from repository.yaml
- rename client to **metrics-tracker-client**