### PR TITLE
Provide Command Line Interface

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+
+'use strict';
+
+const program = require('commander');
+const tracker = require('./tracker');
+
+program
+  .command('track')
+  .action(() => {
+    tracker.track();
+  })
+
+program.parse(process.argv);

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.2.3",
   "private": false,
   "main": "tracker.js",
+  "bin": "./cli.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/IBM/metrics-collector-client-node.git"

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "url": "https://github.com/IBM/metrics-collector-client-node.git"
   },
   "dependencies": {
+    "commander": "^2.15.1",
     "cwd": "^0.10.0",
     "js-yaml": "^3.10.0",
     "restler": "^3.4.0"


### PR DESCRIPTION
Some demo apps do not have a main entry point (such as `app.js`). For example, some apps rely on a `serve` or a `start` command provided by the selected framework's CLI. In these types of apps there is no way way integrate deployment tracking without adding an unnecessary entry point. This pull request adds a `track` command which can be called from within the `scripts` section of a project's `package.json` file.

Here is an example of how this might be used within a Preact app (note the `metrics-tracker-client track` part of the `serve` script):

```json
  "scripts": {
    "start": "if-env NODE_ENV=production && npm run -s serve || npm run -s dev",
    "build": "preact build --no-prerender --template=./index.html --dest=./docs --clean",
    "test": "eslint src && karma start --single-run --browsers ChromeHeadless karma.conf.js",
    "serve": "preact build --no-prerender --template=./index.html --dest=./docs --clean && metrics-tracker-client track && preact serve",
    "dev": "preact watch --template=./index.html --config=./preact.config.js"
  },
```